### PR TITLE
Improve ENVI file load performance

### DIFF
--- a/R/read_envi.R
+++ b/R/read_envi.R
@@ -90,7 +90,10 @@ read_envi <- function(file, header = NULL, spectral_smooth = F, sigma = c(1,1,1)
     y = rep(0:(dims[1] - 1), times = dims[2]),
     x = rep(0:(dims[2] - 1), each = dims[1])
   )
-  spectra <- matrix(aperm(arr, c(3, 1, 2)), nrow = dims[3])
+  spectra <- data.table::as.data.table(
+    matrix(aperm(arr, c(3, 1, 2)), nrow = dims[3])
+  )
+  data.table::setnames(spectra, paste(coords$y, coords$x, sep = "_"))
 
   if("wavelength" %in% names(hdr)) {
       wavenumbers <- hdr$wavelength

--- a/R/read_envi.R
+++ b/R/read_envi.R
@@ -39,7 +39,6 @@
 #' \code{\link[mmand]{gaussianSmooth}()}
 #'
 #' @importFrom utils modifyList
-#' @importFrom data.table as.data.table dcast
 #' @importFrom caTools read.ENVI
 #' @importFrom mmand gaussianSmooth
 #' @export
@@ -81,39 +80,40 @@ read_envi <- function(file, header = NULL, spectral_smooth = F, sigma = c(1,1,1)
   hdr <- .read_envi_header(header)
   arr <- read.ENVI(file, header)
 
-  if(spectral_smooth) {
-    dt <- arr |>
-      gaussianSmooth(sigma) |>
-      as.data.table()
-  } else {
-    dt <- as.data.table(arr)
-  }
+  if(spectral_smooth)
+    arr <- gaussianSmooth(arr, sigma)
+
   md <- hdr[names(hdr) != "wavelength"]
-  names(dt) <- c("y", "x", "z", "value")
-  dt[, 1:2] <- dt[, 1:2] -1
-  if("wavelength" %in% names(hdr)){
+
+  dims <- dim(arr)
+  coords <- data.frame(
+    y = rep(0:(dims[1] - 1), times = dims[2]),
+    x = rep(0:(dims[2] - 1), each = dims[1])
+  )
+  spectra <- matrix(aperm(arr, c(3, 1, 2)), nrow = dims[3])
+
+  if("wavelength" %in% names(hdr)) {
       wavenumbers <- hdr$wavelength
-  }
-  else if(grepl("\\.img$", file) & file.exists(gsub("\\.img$", ".parms", file))){
+  } else if(grepl("\\.img$", file) & file.exists(gsub("\\.img$", ".parms", file))) {
       metadata <- readLines(gsub("\\.img$", ".parms", file))
       names <- gsub("=.*", "", metadata)
       vals <- gsub(".*=", "", metadata)
-      df_metadata <- as.data.table(t(vals))
+      df_metadata <- as.data.frame(t(vals))
       colnames(df_metadata) <- names
-      wavenumbers = seq(to = as.numeric(df_metadata[["LXV"]]), 
-                        from = as.numeric(df_metadata[["FXV"]]), 
-                        length.out = as.numeric(df_metadata[["NPT"]]))
-  }
-  else{
-      wavenumbers = NULL
+      wavenumbers <- seq(to = as.numeric(df_metadata[["LXV"]]),
+                         from = as.numeric(df_metadata[["FXV"]]),
+                         length.out = as.numeric(df_metadata[["NPT"]]))
+  } else {
+      wavenumbers <- NULL
   }
 
-  if(is.null(wavenumbers)) warning("wavenumbers not found, using index values instead")
-  
-  os <- as_OpenSpecy(x = if(!is.null(wavenumbers)) wavenumbers else 1:dim(arr)[3],
-                     spectra = dcast(dt, z ~ y + x)[, -1],
+  if(is.null(wavenumbers))
+    warning("wavenumbers not found, using index values instead")
+
+  os <- as_OpenSpecy(x = if(!is.null(wavenumbers)) wavenumbers else 1:dims[3],
+                     spectra = spectra,
                      metadata = c(metadata, md),
-                     coords = dt[, 1:2] |> unique(),
+                     coords = coords,
                      session_id = T)
 
   return(os)

--- a/R/read_envi.R
+++ b/R/read_envi.R
@@ -87,8 +87,8 @@ read_envi <- function(file, header = NULL, spectral_smooth = F, sigma = c(1,1,1)
 
   dims <- dim(arr)
   coords <- data.frame(
-    y = rep(0:(dims[1] - 1), each = dims[2]),
-    x = rep(0:(dims[2] - 1), times = dims[1])
+    y = as.numeric(rep(seq_len(dims[1]) - 1, each = dims[2])),
+    x = as.numeric(rep(seq_len(dims[2]) - 1, times = dims[1]))
   )
   spectra <- data.table::as.data.table(
     matrix(aperm(arr, c(3, 2, 1)), nrow = dims[3])

--- a/R/read_envi.R
+++ b/R/read_envi.R
@@ -87,11 +87,11 @@ read_envi <- function(file, header = NULL, spectral_smooth = F, sigma = c(1,1,1)
 
   dims <- dim(arr)
   coords <- data.frame(
-    y = rep(0:(dims[1] - 1), times = dims[2]),
-    x = rep(0:(dims[2] - 1), each = dims[1])
+    y = rep(0:(dims[1] - 1), each = dims[2]),
+    x = rep(0:(dims[2] - 1), times = dims[1])
   )
   spectra <- data.table::as.data.table(
-    matrix(aperm(arr, c(3, 1, 2)), nrow = dims[3])
+    matrix(aperm(arr, c(3, 2, 1)), nrow = dims[3])
   )
   data.table::setnames(spectra, paste(coords$y, coords$x, sep = "_"))
 


### PR DESCRIPTION
## Summary
- Rework `read_envi()` to avoid costly `data.table` reshaping and cast arrays directly to spectra matrices
- Simplify coordinate generation and metadata handling for faster import of large ENVI files

## Testing
- `R CMD check .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0866a7fb4832093a75911a6b245da